### PR TITLE
Publisher confirms

### DIFF
--- a/bg_utils/thrift/beergarden.thrift
+++ b/bg_utils/thrift/beergarden.thrift
@@ -5,6 +5,10 @@ exception BaseException {
   1: string message
 }
 
+exception PublishException {
+  1: string message
+}
+
 exception InvalidRequest {
   1: string id,
   2: string message
@@ -41,7 +45,8 @@ service BartenderBackend {
 
 
   // Requests
-  void processRequest(1:string id) throws (1:InvalidRequest ex, 2:BaseException baseEx);
+  void processRequest(1:string id) throws (1:InvalidRequest ex, 2: PublishException pubEx,
+    3:BaseException baseEx);
 
 
   // Queues

--- a/test/unit/pika_test.py
+++ b/test/unit/pika_test.py
@@ -88,12 +88,13 @@ class TransientPikaClientTest(unittest.TestCase):
         props_mock.return_value = {}
         message_mock = Mock(id='id', command='foo', status=None)
 
-        self.client.publish(message_mock, routing_key='queue_name', expiration=10)
+        self.client.publish(message_mock, routing_key='queue_name', expiration=10, mandatory=True)
         props_mock.assert_called_with(app_id='beer-garden', content_type='text/plain',
                                       headers=None, expiration=10)
         self.channel_mock.basic_publish.assert_called_with(exchange='beer_garden',
                                                            routing_key='queue_name',
-                                                           body=message_mock, properties={})
+                                                           body=message_mock, properties={},
+                                                           mandatory=True)
 
     def test_get_routing_key(self):
         self.assertEqual('system.1-0-0.instance', get_routing_key('system', '1.0.0', 'instance'))


### PR DESCRIPTION
This adds support for publishing to Pika with confirms (fail if there was an error publishing) and/or the mandatory flag (fail if the message was not routed to any queues).