### PR TITLE
Issue/79

### DIFF
--- a/bg_utils/__init__.py
+++ b/bg_utils/__init__.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import logging
 import logging.config
@@ -6,6 +7,7 @@ from argparse import ArgumentParser
 from io import open
 
 import six
+import sys
 import thriftpy
 import yapconf
 
@@ -142,10 +144,52 @@ def load_application_config(spec, cli_args):
         else:
             file_type = 'yaml'
         filename = temp_config.configuration.file
-        spec.add_source(filename, file_type, filename=filename)
+        _safe_migrate(spec, filename, file_type)
+        spec.add_source(filename, 'yaml', filename=filename)
         config_sources.insert(1, filename)
 
     return spec.load_config(*config_sources)
+
+
+def _safe_migrate(spec, filename, file_type):
+    tmp_filename = filename + '.tmp'
+    try:
+        spec.migrate_config_file(
+            filename,
+            current_file_type=file_type,
+            output_file_name=tmp_filename,
+            output_file_type='yaml',
+        )
+    except Exception:
+        sys.stderr.write(
+            'Could not successfully migrate application configuration.'
+            'will attempt to load the previous configuration.'
+        )
+        return
+    _swap_files(filename, tmp_filename)
+
+
+def _swap_files(filename, tmp_filename):
+    try:
+        os.rename(filename, filename + '_' + datetime.datetime.utcnow().isoformat())
+    except Exception:
+        sys.stderr.write(
+            'Could not backup the old configuration. Cowardly refusing to overwrite '
+            'the current configuration with the old configuration. This could cause '
+            'problems later. Please see %s for the new configuration file' % tmp_filename
+        )
+        return
+
+    try:
+        os.rename(tmp_filename, filename)
+    except Exception:
+        sys.stderr.write(
+            'ERROR: Config migration was a success, but we could not move the '
+            'new config into the old config value. Maybe a permission issue? '
+            'Beer Garden cannot start now. To resolve this, you need to rename '
+            '%s to %s' % (tmp_filename, filename)
+        )
+        raise
 
 
 def setup_application_logging(config, default_config):

--- a/bg_utils/__init__.py
+++ b/bg_utils/__init__.py
@@ -126,7 +126,10 @@ def generate_logging_config_file(spec, logging_config_generator, cli_args):
 
 def load_application_config(spec, cli_args):
 
-    config_sources = [cli_args, 'ENVIRONMENT']
+    spec.add_source('cli_args', 'dict', data=cli_args)
+    spec.add_source('ENVIRONMENT', 'environment')
+
+    config_sources = ['cli_args', 'ENVIRONMENT']
 
     # Load bootstrap items to see if there's a config file
     temp_config = spec.load_config(*config_sources, bootstrap=True)
@@ -138,7 +141,9 @@ def load_application_config(spec, cli_args):
             file_type = 'json'
         else:
             file_type = 'yaml'
-        config_sources.insert(1, ('config file', temp_config.configuration.file, file_type))
+        filename = temp_config.configuration.file
+        spec.add_source(filename, file_type, filename=filename)
+        config_sources.insert(1, filename)
 
     return spec.load_config(*config_sources)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -66,4 +66,4 @@ virtualenv==16.0.0        # via tox
 watchdog==0.8.3
 wheel==0.31.1
 wrapt==1.10.11            # via brewtils
-yapconf[yaml]==0.3.2
+yapconf[yaml]==0.3.3

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,6 @@ setup(
         'mongoengine',
         'ruamel.yaml',
         'thriftpy',
-        'yapconf>=0.3.1',
+        'yapconf>=0.3.3',
     ]
 )

--- a/test/unit/init_test.py
+++ b/test/unit/init_test.py
@@ -320,7 +320,7 @@ class TestBgUtils(object):
         cli_args = {'configuration': {'file': old_filename, 'type': 'json'}}
 
         with open(old_filename, 'w') as f:
-            f.write(json.dumps(old_config))
+            f.write(json.dumps(old_config, ensure_ascii=False))
 
         spec.migrate_config_file = Mock(side_effect=ValueError)
         generated_config = bg_utils.load_application_config(spec, cli_args)
@@ -338,7 +338,7 @@ class TestBgUtils(object):
         cli_args = {'configuration': {'file': old_filename, 'type': 'json'}}
 
         with open(old_filename, 'w') as f:
-            f.write(json.dumps(old_config))
+            f.write(json.dumps(old_config, ensure_ascii=False))
 
         with patch('os.rename', Mock(side_effect=ValueError)):
             generated_config = bg_utils.load_application_config(spec, cli_args)
@@ -361,7 +361,7 @@ class TestBgUtils(object):
         cli_args = {'configuration': {'file': old_filename, 'type': 'json'}}
 
         with open(old_filename, 'w') as f:
-            f.write(json.dumps(old_config))
+            f.write(json.dumps(old_config, ensure_ascii=False))
 
         with patch('os.rename', Mock(side_effect=[Mock(), ValueError])):
             with pytest.raises(ValueError):
@@ -382,7 +382,7 @@ class TestBgUtils(object):
         }
 
         with open(old_filename, 'w') as f:
-            f.write(json.dumps(old_config))
+            f.write(json.dumps(old_config, ensure_ascii=False))
 
         generated_config = bg_utils.load_application_config(spec, cli_args)
         assert generated_config.log_level == 'INFO'

--- a/test/unit/init_test.py
+++ b/test/unit/init_test.py
@@ -137,10 +137,12 @@ class TestBgUtils(object):
 
         generated_config = bg_utils.load_application_config(spec, cli_args)
         assert generated_config.log_level == 'DEBUG'
+        assert len(spec.sources) == 3
 
     def test_load_application_config_no_file_given(self, spec):
         config = bg_utils.load_application_config(spec, {})
         assert type(config) == Box
+        assert len(spec.sources) == 2
 
     @patch('bg_utils.logging.config.dictConfig')
     def test_setup_application_logging_no_log_config(self, config_mock):

--- a/test/unit/init_test.py
+++ b/test/unit/init_test.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+import json
 import os
 from io import open
 
@@ -7,6 +8,7 @@ import pytest
 from box import Box
 from mock import patch, MagicMock, Mock
 from pymongo.errors import ServerSelectionTimeoutError
+from ruamel import yaml
 from yapconf import YapconfSpec
 
 import bg_utils
@@ -17,7 +19,11 @@ def spec():
     return YapconfSpec({
         'log_config': {'required': False, 'default': None},
         'log_file': {'required': False, 'default': None},
-        'log_level': {'required': False, 'default': 'INFO'},
+        'log_level': {
+            'required': False,
+            'default': 'INFO',
+            'previous_names': ['old_log_level'],
+        },
         'configuration': {
             'type': 'dict',
             'bootstrap': True,
@@ -35,6 +41,18 @@ def spec():
             },
         },
     })
+
+
+@pytest.fixture
+def old_config():
+    return {
+            'log_config': None,
+            'log_file': None,
+            'old_log_level': 'INFO',
+            'configuration': {
+                'type': 'json',
+            }
+        }
 
 
 class TestBgUtils(object):
@@ -295,3 +313,81 @@ class TestBgUtils(object):
 
         with pytest.raises(OperationFailure):
             bg_utils._verify_db()
+
+    def test_safe_migrate_migration_failure(self, tmpdir, spec, old_config):
+        old_filename = os.path.join(str(tmpdir), 'config.json')
+        old_config['configuration']['file'] = old_filename
+        cli_args = {'configuration': {'file': old_filename, 'type': 'json'}}
+
+        with open(old_filename, 'w') as f:
+            f.write(json.dumps(old_config))
+
+        spec.migrate_config_file = Mock(side_effect=ValueError)
+        generated_config = bg_utils.load_application_config(spec, cli_args)
+        assert generated_config.log_level == 'INFO'
+
+        # If the migration fails, we should still have JSON file.
+        with open(old_filename) as f:
+            new_config_value = json.load(f)
+
+        assert new_config_value == old_config
+
+    def test_safe_migrate_initial_rename_failure(self, tmpdir, spec, old_config):
+        old_filename = os.path.join(str(tmpdir), 'config.json')
+        old_config['configuration']['file'] = old_filename
+        cli_args = {'configuration': {'file': old_filename, 'type': 'json'}}
+
+        with open(old_filename, 'w') as f:
+            f.write(json.dumps(old_config))
+
+        with patch('os.rename', Mock(side_effect=ValueError)):
+            generated_config = bg_utils.load_application_config(spec, cli_args)
+
+        assert generated_config.log_level == 'INFO'
+
+        # The tmp file should still be there.
+        with open(old_filename + '.tmp') as f:
+            yaml.safe_load(f)
+
+        # However the loaded config, should be a JSON file.
+        with open(old_filename) as f:
+            new_config_value = json.load(f)
+
+        assert new_config_value == old_config
+
+    def test_safe_migrate_catastrophe(self, tmpdir, spec, old_config):
+        old_filename = os.path.join(str(tmpdir), 'config.json')
+        old_config['configuration']['file'] = old_filename
+        cli_args = {'configuration': {'file': old_filename, 'type': 'json'}}
+
+        with open(old_filename, 'w') as f:
+            f.write(json.dumps(old_config))
+
+        with patch('os.rename', Mock(side_effect=[Mock(), ValueError])):
+            with pytest.raises(ValueError):
+                bg_utils.load_application_config(spec, cli_args)
+
+    def test_safe_migrate_success(self, tmpdir, spec, old_config):
+        old_filename = os.path.join(str(tmpdir), 'config.json')
+        old_config['configuration']['file'] = old_filename
+        cli_args = {'configuration': {'file': old_filename, 'type': 'json'}}
+        expected_new_config = {
+            'log_config': None,
+            'log_file': None,
+            'log_level': 'INFO',
+            'configuration': {
+                'file': old_filename,
+                'type': 'json'
+            }
+        }
+
+        with open(old_filename, 'w') as f:
+            f.write(json.dumps(old_config))
+
+        generated_config = bg_utils.load_application_config(spec, cli_args)
+        assert generated_config.log_level == 'INFO'
+
+        with open(old_filename) as f:
+            new_config_value = yaml.safe_load(f)
+
+        assert new_config_value == expected_new_config


### PR DESCRIPTION
# Note

You should accept #13 first.

This commit allows beer-garden to safely migrate from JSON config
files to YAML config files. There is one error case, when moving
the files around could cause application startup to fail. I believe
this is mostly mitigated because we perform the scary operation
last which should throw an error before catastrophic failure
occurrs.

We also guarantee that the file will be yaml. Since yaml is a
superset of JSON, the yaml parser can load JSON just fine in
the event that migrating/moving the YAML file does not complete
successfully.