### PR TITLE
Fixing instance index names

### DIFF
--- a/bg_utils/__init__.py
+++ b/bg_utils/__init__.py
@@ -512,6 +512,9 @@ def _check_indexes(document_class):
         spec = document_class.list_indexes()
         existing = document_class._get_collection().index_information()
 
+        if document_class == Request and 'parent_instance_index' in existing:
+            raise OperationFailure('Old Request index found, rebuilding')
+
         if len(spec) > len(existing):
             logger.warning('Found missing %s indexes, about to build them. '
                            'This could take a while :)',

--- a/bg_utils/models.py
+++ b/bg_utils/models.py
@@ -270,7 +270,7 @@ class Request(Document, BrewtilsRequest):
                 'fields': ['has_parent', 'system'],
             },
             {
-                'name': 'parent_instance_index',
+                'name': 'parent_instance_name_index',
                 'fields': ['has_parent', 'instance_name'],
             },
             {
@@ -294,7 +294,7 @@ class Request(Document, BrewtilsRequest):
                 'fields': ['has_parent', '-created_at', 'system'],
             },
             {
-                'name': 'parent_created_at_instance_index',
+                'name': 'parent_created_at_instance_name_index',
                 'fields': ['has_parent', '-created_at', 'instance_name'],
             },
             {


### PR DESCRIPTION
This is part of beer-garden/beer-garden#105. It corrects the index names for the `instance_name` field.

WIP because of need to add tests for correcting old index name.