### PR TITLE
Bumping thriftpy2 version, changing import name

### DIFF
--- a/bg_utils/__init__.py
+++ b/bg_utils/__init__.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from io import open
 
 import six
-import thriftpy
+import thriftpy2
 import yapconf
 from ruamel.yaml import YAML
 
@@ -18,7 +18,7 @@ __version__ = generated_version
 
 logger = logging.getLogger(__name__)
 
-bg_thrift = thriftpy.load(
+bg_thrift = thriftpy2.load(
     os.path.join(os.path.dirname(__file__), "thrift", "beergarden.thrift"),
     include_dirs=[os.path.join(os.path.dirname(__file__), "thrift")],
     module_name="bg_thrift",

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ pbr==4.2.0                # via mock
 pika==0.12.0
 pkginfo==1.4.2            # via twine
 pluggy==0.7.1             # via pytest, tox
-ply==3.11                 # via thriftpy
+ply==3.11                 # via thriftpy2
 py==1.5.4                 # via pytest, tox
 pycodestyle==2.3.1        # via flake8
 pyflakes==1.6.0           # via flake8
@@ -65,7 +65,7 @@ snowballstemmer==1.2.1    # via sphinx
 sphinx-rtd-theme==0.4.1
 sphinx==1.7.6
 sphinxcontrib-websupport==1.1.0  # via sphinx
-thriftpy2==0.3.11
+thriftpy2==0.4.0
 toml==0.10.0              # via black
 tox==3.1.3
 tqdm==4.24.0              # via twine

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         "pika<0.13",
         "pytz<2019",
         "ruamel.yaml<0.16",
-        "thriftpy2<0.4",
+        "thriftpy2<0.5",
         "yapconf>=0.3.3",
     ],
 )


### PR DESCRIPTION
This is part of the fix for beer-garden/beer-garden#229.