### PR TITLE
Application start config migrate now won't migrate bootstrap entries

### DIFF
--- a/bg_utils/__init__.py
+++ b/bg_utils/__init__.py
@@ -217,11 +217,12 @@ def _safe_migrate(spec, filename, file_type):
             current_file_type=file_type,
             output_file_name=tmp_filename,
             output_file_type=file_type,
+            include_bootstrap=False,
         )
     except Exception:
         sys.stderr.write(
-            "Could not successfully migrate application configuration."
-            "will attempt to load the previous configuration."
+            "Could not successfully migrate application configuration. "
+            "Will attempt to load the previous configuration."
         )
         return
     if _is_new_config(filename, file_type, tmp_filename):


### PR DESCRIPTION
Having bootstrap entries in the config files is not great - they aren't ever used, so they can only be a source of confusion.

The upgrade path excludes bootstrap items from the config migration to avoid this confusion.

This change brings the application config loading in line with that behavior, since without this change upgrading will remove the `configuration` items, but starting the application will add them back.