### PR TITLE
Issue/224

### DIFF
--- a/bg_utils/__init__.py
+++ b/bg_utils/__init__.py
@@ -217,11 +217,12 @@ def _safe_migrate(spec, filename, file_type):
             current_file_type=file_type,
             output_file_name=tmp_filename,
             output_file_type=file_type,
+            include_bootstrap=False,
         )
     except Exception:
         sys.stderr.write(
-            "Could not successfully migrate application configuration."
-            "will attempt to load the previous configuration."
+            "Could not successfully migrate application configuration. "
+            "Will attempt to load the previous configuration."
         )
         return
     if _is_new_config(filename, file_type, tmp_filename):

--- a/bg_utils/__init__.py
+++ b/bg_utils/__init__.py
@@ -93,8 +93,17 @@ def generate_config_file(spec, cli_args):
     """
     config = _generate_config(spec, cli_args)
 
+    # Bootstrap items shouldn't be in the generated config file
+    # We mimic a migration as it's the easiest way to filter out bootstrap items
+    items = [item for item in spec._yapconf_items.values() if not item.bootstrap]
+    filtered_config = {}
+    for item in items:
+        item.migrate_config(
+            config, filtered_config, always_update=True, update_defaults=True
+        )
+
     yapconf.dump_data(
-        config.to_dict(),
+        filtered_config,
         filename=config.configuration.file,
         file_type=_get_config_type(config),
     )

--- a/test/unit/init_test.py
+++ b/test/unit/init_test.py
@@ -250,6 +250,16 @@ class TestGenerateConfig(object):
         # Just make sure we printed something
         assert capsys.readouterr().out
 
+    def test_omit_bootstrap(self, spec, tmpdir):
+        filename = os.path.join(str(tmpdir), "temp.yaml")
+        bg_utils.generate_config_file(spec, ["-c", filename])
+
+        with open(filename) as f:
+            config = yaml.safe_load(f)
+
+        assert "log" in config
+        assert "configuration" not in config
+
 
 class TestUpdateConfig(object):
     @pytest.mark.parametrize(

--- a/test/unit/init_test.py
+++ b/test/unit/init_test.py
@@ -14,80 +14,81 @@ import bg_utils
 import bg_utils.mongo.models
 
 
+@pytest.fixture
+def spec():
+    return YapconfSpec(
+        {
+            "log": {
+                "type": "dict",
+                "items": {
+                    "config_file": {
+                        "type": "str",
+                        "description": "Path to a logging config file.",
+                        "required": False,
+                        "cli_short_name": "l",
+                        "previous_names": ["log_config"],
+                        "alt_env_names": ["LOG_CONFIG"],
+                    },
+                    "file": {
+                        "type": "str",
+                        "description": "File you would like the application to log to",
+                        "required": False,
+                        "previous_names": ["log_file"],
+                    },
+                    "level": {
+                        "type": "str",
+                        "description": "Log level for the application",
+                        "default": "INFO",
+                        "choices": [
+                            "DEBUG",
+                            "INFO",
+                            "WARN",
+                            "WARNING",
+                            "ERROR",
+                            "CRITICAL",
+                        ],
+                        "previous_names": ["log_level"],
+                    },
+                },
+            },
+            "configuration": {
+                "type": "dict",
+                "bootstrap": True,
+                "items": {
+                    "file": {
+                        "required": False,
+                        "bootstrap": True,
+                        "cli_short_name": "c",
+                    },
+                    "type": {
+                        "required": False,
+                        "bootstrap": True,
+                        "cli_short_name": "t",
+                    },
+                },
+            },
+        }
+    )
+
+
+@pytest.fixture
+def old_config():
+    """Represent an un-migrated config with previous default values."""
+    return {
+        "log_config": None,
+        "log_file": None,
+        "log_level": "INFO",
+        "configuration": {"type": "json"},
+    }
+
+
+@pytest.fixture
+def new_config():
+    """Represents a up-to-date config with all new values."""
+    return {"log": {"config_file": None, "file": None, "level": "INFO"}}
+
+
 class TestBgUtils(object):
-    @pytest.fixture
-    def spec(self):
-        return YapconfSpec(
-            {
-                "log": {
-                    "type": "dict",
-                    "items": {
-                        "config_file": {
-                            "type": "str",
-                            "description": "Path to a logging config file.",
-                            "required": False,
-                            "cli_short_name": "l",
-                            "previous_names": ["log_config"],
-                            "alt_env_names": ["LOG_CONFIG"],
-                        },
-                        "file": {
-                            "type": "str",
-                            "description": "File you would like the application to log to",
-                            "required": False,
-                            "previous_names": ["log_file"],
-                        },
-                        "level": {
-                            "type": "str",
-                            "description": "Log level for the application",
-                            "default": "INFO",
-                            "choices": [
-                                "DEBUG",
-                                "INFO",
-                                "WARN",
-                                "WARNING",
-                                "ERROR",
-                                "CRITICAL",
-                            ],
-                            "previous_names": ["log_level"],
-                        },
-                    },
-                },
-                "configuration": {
-                    "type": "dict",
-                    "bootstrap": True,
-                    "items": {
-                        "file": {
-                            "required": False,
-                            "bootstrap": True,
-                            "cli_short_name": "c",
-                        },
-                        "type": {
-                            "required": False,
-                            "bootstrap": True,
-                            "cli_short_name": "t",
-                        },
-                    },
-                },
-            }
-        )
-
-    @pytest.fixture
-    def old_config(self):
-        """Represent an un-migrated config with previous default values."""
-        return {
-            "log_config": None,
-            "log_file": None,
-            "log_level": "INFO",
-            "configuration": {"type": "json"},
-        }
-
-    @pytest.fixture
-    def new_config(self):
-        """Represents a up-to-date config with all new values."""
-        return {
-            "log": {"config_file": None, "file": None, "level": "INFO"},
-        }
-
     def test_parse_args(self, spec):
         cli_args = [
             "--log-config-file",
@@ -107,122 +108,6 @@ class TestBgUtils(object):
                 "level": "INFO",
             }
         }
-
-    def test_generate_config(self, spec):
-        config = bg_utils._generate_config(spec, ["-c", "/path/to/config"])
-        assert config.log.file is None
-        assert config.log.config_file is None
-        assert config.log.level == "INFO"
-        assert config.configuration.file == "/path/to/config"
-
-    @pytest.mark.parametrize("file_type", ["json", "yaml"])
-    def test_generate_config_file(self, spec, tmpdir, file_type):
-        filename = os.path.join(str(tmpdir), "temp." + file_type)
-        bg_utils.generate_config_file(spec, ["-c", filename, "-t", file_type])
-
-        assert os.path.getsize(filename) > 0
-
-    @pytest.mark.parametrize("file_type", ["json", "yaml"])
-    def test_generate_config_file_infer_type(self, spec, tmpdir, file_type):
-        filename = os.path.join(str(tmpdir), "temp." + file_type)
-        bg_utils.generate_config_file(spec, ["-c", filename])
-
-        assert os.path.getsize(filename) > 0
-
-    @pytest.mark.parametrize("file_type", ["json", "yaml"])
-    def test_generate_config_file_print(self, spec, capsys, file_type):
-        bg_utils.generate_config_file(spec, ["-t", file_type])
-
-        # Just make sure we printed something
-        assert capsys.readouterr().out
-
-    @pytest.mark.parametrize(
-        "extension,file_type",
-        [
-            ("json", "json"),
-            ("yaml", "yaml"),
-            ("yml", "yaml"),
-        ]
-    )
-    def test_update_config(self, monkeypatch, spec, extension, file_type):
-        migrate_mock = Mock()
-        spec.migrate_config_file = migrate_mock
-        spec.update_defaults = Mock()
-
-        remove_mock = Mock()
-        monkeypatch.setattr(os, "remove", remove_mock)
-
-        bg_utils.update_config_file(spec, ["-c", "/path/to/config." + extension])
-
-        expected = Box(
-            {
-                "log_file": None,
-                "log_level": "INFO",
-                "log_config": None,
-                "configuration": {"file": "/path/to/config." + extension},
-            }
-        )
-        migrate_mock.assert_called_once_with(
-            expected.configuration.file,
-            current_file_type=file_type,
-            output_file_name=expected.configuration.file,
-            output_file_type=file_type,
-            update_defaults=True,
-            include_bootstrap=False,
-        )
-        assert remove_mock.called is False
-
-    @pytest.mark.parametrize(
-        "current_type,new_type",
-        [
-            ("json", "yaml"),
-            ("yaml", "json"),
-        ]
-    )
-    def test_update_config_change_type(self, monkeypatch, spec, current_type, new_type):
-        migrate_mock = Mock()
-        spec.migrate_config_file = migrate_mock
-        spec.update_defaults = Mock()
-
-        remove_mock = Mock()
-        monkeypatch.setattr(os, "remove", remove_mock)
-
-        bg_utils.update_config_file(
-            spec, ["-c", "/path/to/config." + current_type, "-t", new_type]
-        )
-
-        migrate_mock.assert_called_once_with(
-            "/path/to/config." + current_type,
-            current_file_type=current_type,
-            output_file_name="/path/to/config." + new_type,
-            output_file_type=new_type,
-            update_defaults=True,
-            include_bootstrap=False,
-        )
-        remove_mock.assert_called_once_with("/path/to/config." + current_type)
-
-    def test_update_config_change_type_error(self, monkeypatch, spec):
-        migrate_mock = Mock(side_effect=ValueError)
-        spec.migrate_config_file = migrate_mock
-        spec.update_defaults = Mock()
-
-        remove_mock = Mock()
-        monkeypatch.setattr(os, "remove", remove_mock)
-
-        with pytest.raises(ValueError):
-            bg_utils.update_config_file(
-                spec, ["-c", "/path/to/config.json", "-t", "yaml"]
-            )
-        assert remove_mock.called is False
-
-    def test_update_config_no_file_specified(self, spec):
-        migrate_mock = Mock()
-        spec.migrate_config_file = migrate_mock
-
-        with pytest.raises(SystemExit):
-            bg_utils.update_config_file(spec, [])
-
-        assert migrate_mock.called is False
 
     @patch("bg_utils.open")
     def test_generate_logging_config(self, open_mock, spec):
@@ -313,7 +198,175 @@ class TestBgUtils(object):
 
         assert logging_config == generated_config
 
-    def test_safe_migrate_migration_failure(self, capsys, tmpdir, spec, old_config):
+    @pytest.mark.parametrize(
+        "file_name,file_type,expected_type",
+        [
+            (None, None, "yaml"),
+            (None, "yaml", "yaml"),
+            (None, "json", "json"),
+            ("file", None, "yaml"),
+            ("file", "yaml", "yaml"),
+            ("file", "json", "json"),
+            ("file.yaml", None, "yaml"),
+            ("file.blah", None, "yaml"),
+            ("file.json", None, "json"),
+            ("file.yaml", "yaml", "yaml"),
+            ("file.yaml", "json", "json"),
+            ("file.json", "yaml", "yaml"),
+            ("file.json", "json", "json"),
+        ],
+    )
+    def test_get_config_type(self, file_name, file_type, expected_type):
+        config = Box({"configuration": {"file": file_name, "type": file_type}})
+        assert bg_utils._get_config_type(config) == expected_type
+
+
+class TestGenerateConfig(object):
+    def test_correctness(self, spec):
+        config = bg_utils._generate_config(spec, ["-c", "/path/to/config"])
+        assert config.log.file is None
+        assert config.log.config_file is None
+        assert config.log.level == "INFO"
+        assert config.configuration.file == "/path/to/config"
+
+    @pytest.mark.parametrize("file_type", ["json", "yaml"])
+    def test_create_file(self, spec, tmpdir, file_type):
+        filename = os.path.join(str(tmpdir), "temp." + file_type)
+        bg_utils.generate_config_file(spec, ["-c", filename, "-t", file_type])
+
+        assert os.path.getsize(filename) > 0
+
+    @pytest.mark.parametrize("file_type", ["json", "yaml"])
+    def test_file_infer_type(self, spec, tmpdir, file_type):
+        filename = os.path.join(str(tmpdir), "temp." + file_type)
+        bg_utils.generate_config_file(spec, ["-c", filename])
+
+        assert os.path.getsize(filename) > 0
+
+    @pytest.mark.parametrize("file_type", ["json", "yaml"])
+    def test_stdout(self, spec, capsys, file_type):
+        bg_utils.generate_config_file(spec, ["-t", file_type])
+
+        # Just make sure we printed something
+        assert capsys.readouterr().out
+
+
+class TestUpdateConfig(object):
+    @pytest.mark.parametrize(
+        "extension,file_type", [("json", "json"), ("yaml", "yaml"), ("yml", "yaml")]
+    )
+    def test_success(self, monkeypatch, spec, extension, file_type):
+        migrate_mock = Mock()
+        spec.migrate_config_file = migrate_mock
+        spec.update_defaults = Mock()
+
+        remove_mock = Mock()
+        monkeypatch.setattr(os, "remove", remove_mock)
+
+        bg_utils.update_config_file(spec, ["-c", "/path/to/config." + extension])
+
+        expected = Box(
+            {
+                "log_file": None,
+                "log_level": "INFO",
+                "log_config": None,
+                "configuration": {"file": "/path/to/config." + extension},
+            }
+        )
+        migrate_mock.assert_called_once_with(
+            expected.configuration.file,
+            current_file_type=file_type,
+            output_file_name=expected.configuration.file,
+            output_file_type=file_type,
+            update_defaults=True,
+            include_bootstrap=False,
+        )
+        assert remove_mock.called is False
+
+    @pytest.mark.parametrize(
+        "current_type,new_type", [("json", "yaml"), ("yaml", "json")]
+    )
+    def test_change_type(self, monkeypatch, spec, current_type, new_type):
+        migrate_mock = Mock()
+        spec.migrate_config_file = migrate_mock
+        spec.update_defaults = Mock()
+
+        remove_mock = Mock()
+        monkeypatch.setattr(os, "remove", remove_mock)
+
+        bg_utils.update_config_file(
+            spec, ["-c", "/path/to/config." + current_type, "-t", new_type]
+        )
+
+        migrate_mock.assert_called_once_with(
+            "/path/to/config." + current_type,
+            current_file_type=current_type,
+            output_file_name="/path/to/config." + new_type,
+            output_file_type=new_type,
+            update_defaults=True,
+            include_bootstrap=False,
+        )
+        remove_mock.assert_called_once_with("/path/to/config." + current_type)
+
+    def test_change_type_error(self, monkeypatch, spec):
+        migrate_mock = Mock(side_effect=ValueError)
+        spec.migrate_config_file = migrate_mock
+        spec.update_defaults = Mock()
+
+        remove_mock = Mock()
+        monkeypatch.setattr(os, "remove", remove_mock)
+
+        with pytest.raises(ValueError):
+            bg_utils.update_config_file(
+                spec, ["-c", "/path/to/config.json", "-t", "yaml"]
+            )
+        assert remove_mock.called is False
+
+    def test_no_file_specified(self, spec):
+        migrate_mock = Mock()
+        spec.migrate_config_file = migrate_mock
+
+        with pytest.raises(SystemExit):
+            bg_utils.update_config_file(spec, [])
+
+        assert migrate_mock.called is False
+
+
+class TestSafeMigrate(object):
+    def test_success(self, tmpdir, spec, old_config, new_config):
+        old_filename = os.path.join(str(tmpdir), "config.json")
+        old_config["configuration"]["file"] = old_filename
+        cli_args = {"configuration": {"file": old_filename, "type": "json"}}
+
+        with open(old_filename, "w") as f:
+            f.write(json.dumps(old_config, ensure_ascii=False))
+
+        generated_config = bg_utils.load_application_config(spec, cli_args)
+        assert generated_config.log.level == "INFO"
+
+        with open(old_filename) as f:
+            new_config_value = json.load(f)
+
+        assert new_config_value == new_config
+        assert len(os.listdir(str(tmpdir))) == 2
+
+    def test_no_change(self, tmpdir, spec, new_config):
+        config_file = os.path.join(str(tmpdir), "config.yaml")
+        cli_args = {"configuration": {"file": config_file}}
+
+        with open(config_file, "w") as f:
+            yaml.safe_dump(new_config, f, default_flow_style=False, encoding="utf-8")
+
+        generated_config = bg_utils.load_application_config(spec, cli_args)
+        assert generated_config.log.level == "INFO"
+
+        with open(config_file) as f:
+            new_config_value = yaml.safe_load(f)
+
+        assert new_config_value == new_config
+        assert len(os.listdir(str(tmpdir))) == 1
+
+    def test_migration_failure(self, capsys, tmpdir, spec, old_config):
         old_filename = os.path.join(str(tmpdir), "config.json")
         cli_args = {"configuration": {"file": old_filename, "type": "json"}}
 
@@ -336,7 +389,7 @@ class TestBgUtils(object):
         # And the values should be unchanged
         assert generated_config.log.level == "INFO"
 
-    def test_safe_migrate_rename_failure(self, capsys, tmpdir, spec, old_config):
+    def test_rename_failure(self, capsys, tmpdir, spec, old_config):
         old_filename = os.path.join(str(tmpdir), "config.json")
         cli_args = {"configuration": {"file": old_filename, "type": "json"}}
 
@@ -362,7 +415,7 @@ class TestBgUtils(object):
 
         assert new_config_value == old_config
 
-    def test_safe_migrate_catastrophe(self, capsys, tmpdir, spec, old_config):
+    def test_catastrophe(self, capsys, tmpdir, spec, old_config):
         old_filename = os.path.join(str(tmpdir), "config.json")
         cli_args = {"configuration": {"file": old_filename, "type": "json"}}
 
@@ -378,58 +431,3 @@ class TestBgUtils(object):
 
         # Both the tmp file and the old JSON should still be there.
         assert len(os.listdir(str(tmpdir))) == 2
-
-    def test_safe_migrate_success(self, tmpdir, spec, old_config, new_config):
-        old_filename = os.path.join(str(tmpdir), "config.json")
-        old_config["configuration"]["file"] = old_filename
-        cli_args = {"configuration": {"file": old_filename, "type": "json"}}
-
-        with open(old_filename, "w") as f:
-            f.write(json.dumps(old_config, ensure_ascii=False))
-
-        generated_config = bg_utils.load_application_config(spec, cli_args)
-        assert generated_config.log.level == "INFO"
-
-        with open(old_filename) as f:
-            new_config_value = json.load(f)
-
-        assert new_config_value == new_config
-        assert len(os.listdir(str(tmpdir))) == 2
-
-    def test_safe_migrate_no_change(self, tmpdir, spec, new_config):
-        config_file = os.path.join(str(tmpdir), "config.yaml")
-        cli_args = {"configuration": {"file": config_file}}
-
-        with open(config_file, "w") as f:
-            yaml.safe_dump(new_config, f, default_flow_style=False, encoding="utf-8")
-
-        generated_config = bg_utils.load_application_config(spec, cli_args)
-        assert generated_config.log.level == "INFO"
-
-        with open(config_file) as f:
-            new_config_value = yaml.safe_load(f)
-
-        assert new_config_value == new_config
-        assert len(os.listdir(str(tmpdir))) == 1
-
-    @pytest.mark.parametrize(
-        "file_name,file_type,expected_type",
-        [
-            (None, None, "yaml"),
-            (None, "yaml", "yaml"),
-            (None, "json", "json"),
-            ("file", None, "yaml"),
-            ("file", "yaml", "yaml"),
-            ("file", "json", "json"),
-            ("file.yaml", None, "yaml"),
-            ("file.blah", None, "yaml"),
-            ("file.json", None, "json"),
-            ("file.yaml", "yaml", "yaml"),
-            ("file.yaml", "json", "json"),
-            ("file.json", "yaml", "yaml"),
-            ("file.json", "json", "json"),
-        ],
-    )
-    def test_get_config_type(self, file_name, file_type, expected_type):
-        config = Box({"configuration": {"file": file_name, "type": file_type}})
-        assert bg_utils._get_config_type(config) == expected_type


### PR DESCRIPTION
This fixes beer-garden/beer-garden#224.

Having bootstrap entries in the config files is not great - they aren't ever used, so they can only be a source of confusion.

The rpm upgrade path already excludes bootstrap items from the config migration to avoid this confusion.

This change brings the application config loading in line with that behavior, since without this change upgrading will remove the `configuration` items, but starting the application will add them back. It also removes them from config files generated using `bg_utils.generate_config_file`.